### PR TITLE
時刻同期時、設定時刻が間違って登録される。

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "jp.osdn.gokigen.aira01c"
         minSdk = 14
         targetSdk = 35
-        versionCode = 100000
-        versionName = "1.0.0"
+        versionCode = 100001
+        versionName = "1.0.1"
         multiDexEnabled = true
     }
 

--- a/app/src/main/java/jp/osdn/gokigen/aira01c/camera/omds/operation/OmdsTimeSync.kt
+++ b/app/src/main/java/jp/osdn/gokigen/aira01c/camera/omds/operation/OmdsTimeSync.kt
@@ -42,6 +42,8 @@ class OmdsTimeSync(private val activity: FragmentActivity, private val messageDr
                 val mn = String.format(Locale.US, "%02d", minute.toInt())
                 "${plus}${hr}${mn}"
             }
+            dateFormat1.timeZone = TimeZone.getTimeZone("UTC")
+            dateFormat2.timeZone = TimeZone.getTimeZone("UTC")
             val utcTime = "${dateFormat1.format(currentDateTime)}T${dateFormat2.format(currentDateTime)}"
             val setTimeString = "utctime=${utcTime}&utcdiff=${timezone}"
             Log.v(TAG, " setTimeSync : $setTimeString ($timezone)")


### PR DESCRIPTION
時刻同期機能を使用したとき、本来はUTC時刻を送るべきところ、ローカル時刻を送っていたため、UTC時刻との差分が撮影時刻として発生してしまっていたのを修正する。

ローカルタイムをUTC時刻に変更するだけのため、外部的な変更影響はなし。
